### PR TITLE
Added compatibility with upcoming PWA version 7.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2024-10-21
+### Added
+- Added compatibility with upcoming PWA version 7.20.0
+
 ## [1.0.0] - 2023-11-10
 ### Added
 - Adds a page switcher to the header

--- a/frontend/components/Logo/index.jsx
+++ b/frontend/components/Logo/index.jsx
@@ -12,7 +12,11 @@ import connect from './connector';
 const Logo = ({ isSwitchVisible, children }) => (
   isSwitchVisible ? (
     <div className={`${styles.container} engage__logo`}>
-      <img className={styles.image} src={appConfig.logo} alt={appConfig.shopName} />
+      <img
+        className={styles.image}
+        src={appConfig.logo || appConfig.logoFallback}
+        alt={appConfig.shopName}
+      />
     </div>
   ) : children
 );

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@shopgate-ps/pwa-extension-kit": "^0.6.0"
   },
-  "peerDependenciees": {
-    "@shopgate/engage": "^6.22.4"
+  "peerDependencies": {
+    "@shopgate/engage": ">=6.22.4"
   }
 }


### PR DESCRIPTION
This pull request enables compatibility with the upcoming PWA version 7.20.0. It adds a fallback to retrieve the shop logo (theme config setting changed in PWA 7) and updated schema of the `peerDependencies` to make it compatible with PWA versions > 6.x.