### PR TITLE
Allow icons as page switcher buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.4.3] - 2025-04-01
+## [1.5.0] - 2025-06-30
+### Added
+- Enable icons as page switcher buttons
+
+## [1.4.3] - 2025-06-26
 ### Fixed
 - Navigation aligned to the right edge and prevented from overflowing
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This extension adds a page switcher to the standard header. The selected page wi
 
 Set the following value in your Shopgate Connect Admin:
 
+  * `iconSwitch` - (boolean) If `true` the page switcher will be an icon switch (configure the icons in pageLinking)
   * `pageLinking` - (json) Array
     * `label` - (string) The text displayed for the link.
     * `path` - (string) The internal path to the linked page.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@ Set the following value in your Shopgate Connect Admin:
 
   * `iconSwitch` - (boolean) If `true` the page switcher will be an icon switch (configure the icons in pageLinking), default false
   * `pageLinking` - (json) Array
-    * `label` - (string) The text displayed for the link.
+    * `label` - (string) The text displayed for the link or used as alt text for icon buttons.
     * `path` - (string) The internal path to the linked page.
     * `categoryId` - (string) The linked page belongs to this category.
     * `externalUrl` - (string) The URL to an external page. If specified, this URL is used instead of `path`.
     * `icon` - (string) If specified, the switch button will be this icon.
-    * `iconAltText` - (string) For accessibility, add a descriptive label to be announced by screen readers
   * `linkColor` - (string) Color of links.
   * `linkSelectedColor` - (string) Color of the selected link.
   * `underlineOnActive` - (boolean) If `true`, the active link is underlined.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ This extension adds a page switcher to the standard header. The selected page wi
 
 Set the following value in your Shopgate Connect Admin:
 
-  * `iconSwitch` - (boolean) If `true` the page switcher will be an icon switch (configure the icons in pageLinking)
+  * `iconSwitch` - (boolean) If `true` the page switcher will be an icon switch (configure the icons in pageLinking), default false
   * `pageLinking` - (json) Array
     * `label` - (string) The text displayed for the link.
     * `path` - (string) The internal path to the linked page.
     * `categoryId` - (string) The linked page belongs to this category.
     * `externalUrl` - (string) The URL to an external page. If specified, this URL is used instead of `path`.
     * `icon` - (string) If specified, the switch button will be this icon.
+    * `iconAltText` - (string) For accessibility, add a descriptive label to be announced by screen readers
   * `linkColor` - (string) Color of links.
   * `linkSelectedColor` - (string) Color of the selected link.
   * `underlineOnActive` - (boolean) If `true`, the active link is underlined.
@@ -29,22 +30,23 @@ Set the following value in your Shopgate Connect Admin:
       "label": "Women",
       "categoryId": "123",
       "externalUrl": "",
-      "icon": "<svg XYZ></svg>",
+      "icon": "<path XYZ...>"
     },
     {
       "path": "/page/men",
       "label": "Men",
       "categoryId": "456",
       "externalUrl": "",
-      "icon": "<svg XYZ></svg>",
+      "icon": "<path XYZ...>"
     },
     {
       "path": "",
       "label": "Shopgate",
       "categoryId": "",
-      "externalUrl": "https://www.shopgate.com",
+      "externalUrl": "https://www.shopgate.com"
     }
   ],
+  "iconSwitch": true,
   "linkColor": "",
   "linkSelectedColor": "#000",
   "underlineOnActive": false,

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Set the following value in your Shopgate Connect Admin:
     * `path` - (string) The internal path to the linked page.
     * `categoryId` - (string) The linked page belongs to this category.
     * `externalUrl` - (string) The URL to an external page. If specified, this URL is used instead of `path`.
+    * `icon` - (string) If specified, the switch button will be this icon.
   * `linkColor` - (string) Color of links.
   * `linkSelectedColor` - (string) Color of the selected link.
   * `underlineOnActive` - (boolean) If `true`, the active link is underlined.
@@ -26,19 +27,21 @@ Set the following value in your Shopgate Connect Admin:
       "path": "/",
       "label": "Women",
       "categoryId": "123",
-      "externalUrl": ""
+      "externalUrl": "",
+      "icon": "<svg XYZ></svg>",
     },
     {
       "path": "/page/men",
       "label": "Men",
       "categoryId": "456",
-      "externalUrl": ""
+      "externalUrl": "",
+      "icon": "<svg XYZ></svg>",
     },
     {
       "path": "",
       "label": "Shopgate",
       "categoryId": "",
-      "externalUrl": "https://www.shopgate.com"
+      "externalUrl": "https://www.shopgate.com",
     }
   ],
   "linkColor": "",

--- a/extension-config.json
+++ b/extension-config.json
@@ -50,6 +50,15 @@
     }
   ],
   "configuration": {
+    "iconSwitch": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "type": "boolean",
+        "label": "whether page switcher is icon switcher (configure icons in pageLinking)"
+      }
+    },
     "pageLinking": {
       "type": "admin",
       "destination": "frontend",

--- a/extension-config.json
+++ b/extension-config.json
@@ -58,13 +58,15 @@
           "path": "/",
           "label": "Women",
           "categoryId": "123",
-          "externalUrl": ""
+          "externalUrl": "",
+          "icon": null
         },
         {
           "path": "/page/men",
           "label": "Men",
           "categoryId": "456",
-          "externalUrl": ""
+          "externalUrl": "",
+          "icon": null
         },
         {
           "path": "",

--- a/extension-config.json
+++ b/extension-config.json
@@ -68,14 +68,16 @@
           "label": "Women",
           "categoryId": "123",
           "externalUrl": "",
-          "icon": null
+          "icon": null,
+          "iconAltText": "label for icon"
         },
         {
           "path": "/page/men",
           "label": "Men",
           "categoryId": "456",
           "externalUrl": "",
-          "icon": null
+          "icon": null,
+          "iconAltText": "label for icon"
         },
         {
           "path": "",

--- a/extension-config.json
+++ b/extension-config.json
@@ -55,8 +55,8 @@
       "destination": "frontend",
       "default": false,
       "params": {
-        "type": "boolean",
-        "label": "whether page switcher is icon switcher (configure icons in pageLinking)"
+        "type": "checkbox",
+        "label": "whether page switcher is an icon switcher (configure icons in pageLinking)"
       }
     },
     "pageLinking": {

--- a/frontend/components/Logo/style.js
+++ b/frontend/components/Logo/style.js
@@ -4,6 +4,13 @@ import { showSwitcherInHeader } from '../../config';
 
 const { variables } = themeConfig;
 
+// Update styling of the burger icon in the category drawer app bar
+css.global('.category-drawer__app-bar-burger-icon', {
+  position: 'relative',
+  top: 'initial',
+  transform: 'initial',
+});
+
 const container = css({
   alignItems: 'center',
   display: 'flex',

--- a/frontend/components/SwitchHeader/SwitchButton/index.jsx
+++ b/frontend/components/SwitchHeader/SwitchButton/index.jsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { Icon } from '@shopgate/engage/components';
 import connect from './connector';
 import styles from './style';
@@ -42,7 +43,12 @@ const SwitchButton = ({
         onClick={handleClick}
         type="button"
         ref={switchButtonRef}
-        className={isActive ? styles.activeIconButton : styles.iconButton}
+        className={classNames({
+          [styles.activeIconButton]: isActive,
+          selected: isActive,
+          [styles.iconButton]: !isActive,
+        })}
+        aria-label={link.label}
       >
         <Icon content={icon} size={26} />
       </button>

--- a/frontend/components/SwitchHeader/SwitchButton/index.jsx
+++ b/frontend/components/SwitchHeader/SwitchButton/index.jsx
@@ -10,13 +10,15 @@ import styles from './style';
  * @param {boolean} props.isActive Indicates if the button is active or not.
  * @param {Object} props.link The link object that contains the label and other properties.
  * @param {Function} props.setSelection Function to handle the selection change.
+ * @param {boolean} [props.isIconSwitch] Indicates if the button is an icon switch
  * @param {string} [props.icon] optional icon to show as switch
  * @returns {JSX.Element}
  */
 const SwitchButton = ({
-  isActive, link, setSelection, icon,
+  isActive, link, setSelection, icon, isIconSwitch,
 }) => {
   const buttonRef = useRef(null);
+  const switchButtonRef = useRef(null);
 
   /**
    * Sets the current page selection.
@@ -29,12 +31,20 @@ const SwitchButton = ({
     if (isActive && buttonRef.current) {
       buttonRef.current.focus();
     }
+    if (isActive && switchButtonRef.current) {
+      switchButtonRef.current.focus();
+    }
   }, [isActive]);
 
-  if (icon) {
+  if (isIconSwitch && icon) {
     return (
-      <button onClick={handleClick} type="button" ref={buttonRef}>
-        <Icon content={icon} />
+      <button
+        onClick={handleClick}
+        type="button"
+        ref={switchButtonRef}
+        className={isActive ? styles.activeSwitchButton : styles.switchButton}
+      >
+        <Icon content={icon} size={28} />
       </button>
     );
   }
@@ -57,10 +67,12 @@ SwitchButton.propTypes = {
   link: PropTypes.shape().isRequired,
   setSelection: PropTypes.func.isRequired,
   icon: PropTypes.string,
+  isIconSwitch: PropTypes.bool,
 };
 
 SwitchButton.defaultProps = {
   icon: null,
+  isIconSwitch: false,
 };
 
 SwitchButton.defaultProps = {};

--- a/frontend/components/SwitchHeader/SwitchButton/index.jsx
+++ b/frontend/components/SwitchHeader/SwitchButton/index.jsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { Icon } from '@shopgate/engage/components';
 import connect from './connector';
 import styles from './style';
 
@@ -9,9 +10,12 @@ import styles from './style';
  * @param {boolean} props.isActive Indicates if the button is active or not.
  * @param {Object} props.link The link object that contains the label and other properties.
  * @param {Function} props.setSelection Function to handle the selection change.
+ * @param {string} [props.icon] optional icon to show as switch
  * @returns {JSX.Element}
  */
-const SwitchButton = ({ isActive, link, setSelection }) => {
+const SwitchButton = ({
+  isActive, link, setSelection, icon,
+}) => {
   const buttonRef = useRef(null);
 
   /**
@@ -26,6 +30,14 @@ const SwitchButton = ({ isActive, link, setSelection }) => {
       buttonRef.current.focus();
     }
   }, [isActive]);
+
+  if (icon) {
+    return (
+      <button onClick={handleClick} type="button" ref={buttonRef}>
+        <Icon content={icon} />
+      </button>
+    );
+  }
 
   return (
     <button
@@ -44,6 +56,11 @@ SwitchButton.propTypes = {
   isActive: PropTypes.bool.isRequired,
   link: PropTypes.shape().isRequired,
   setSelection: PropTypes.func.isRequired,
+  icon: PropTypes.string,
+};
+
+SwitchButton.defaultProps = {
+  icon: null,
 };
 
 SwitchButton.defaultProps = {};

--- a/frontend/components/SwitchHeader/SwitchButton/index.jsx
+++ b/frontend/components/SwitchHeader/SwitchButton/index.jsx
@@ -42,7 +42,7 @@ const SwitchButton = ({
         onClick={handleClick}
         type="button"
         ref={switchButtonRef}
-        className={isActive ? styles.activeSwitchButton : styles.switchButton}
+        className={isActive ? styles.activeIconButton : styles.iconButton}
       >
         <Icon content={icon} size={28} />
       </button>

--- a/frontend/components/SwitchHeader/SwitchButton/index.jsx
+++ b/frontend/components/SwitchHeader/SwitchButton/index.jsx
@@ -44,7 +44,7 @@ const SwitchButton = ({
         ref={switchButtonRef}
         className={isActive ? styles.activeIconButton : styles.iconButton}
       >
-        <Icon content={icon} size={28} />
+        <Icon content={icon} size={26} />
       </button>
     );
   }

--- a/frontend/components/SwitchHeader/SwitchButton/style.js
+++ b/frontend/components/SwitchHeader/SwitchButton/style.js
@@ -2,7 +2,7 @@ import { css } from 'glamor';
 import { themeConfig } from '@shopgate/engage';
 import { linkColor, linkSelectedColor, underlineOnActive } from '../../../config';
 
-const { colors } = themeConfig;
+const { colors, shadows } = themeConfig;
 
 const button = css({
   display: 'block',
@@ -26,17 +26,25 @@ const activeButton = css({
   },
 }).toString();
 
-const activeSwitchButton = css({
+const activeIconButton = css({
+  boxShadow: shadows.material,
   backgroundColor: colors.light,
   padding: '6px 18px',
+  ':focus-visible': {
+    outline: 'none !important',
+  },
   borderRadius: '50px',
   ' path': {
     stroke: colors.dark,
   },
 }).toString();
 
-const switchButton = css({
+const iconButton = css({
+  padding: '6px 18px',
   borderRadius: '50px',
+  ':focus-visible': {
+    outline: 'none !important',
+  },
   ' path': {
     stroke: colors.shade9,
   },
@@ -45,6 +53,6 @@ const switchButton = css({
 export default {
   button,
   activeButton,
-  switchButton,
-  activeSwitchButton,
+  iconButton,
+  activeIconButton,
 };

--- a/frontend/components/SwitchHeader/SwitchButton/style.js
+++ b/frontend/components/SwitchHeader/SwitchButton/style.js
@@ -29,7 +29,7 @@ const activeButton = css({
 const activeIconButton = css({
   boxShadow: shadows.material,
   backgroundColor: colors.light,
-  padding: '6px 18px',
+  padding: '4px 12px',
   borderRadius: '50px',
   ':focus-visible': {
     outline: 'none !important',
@@ -37,7 +37,7 @@ const activeIconButton = css({
 }).toString();
 
 const iconButton = css({
-  padding: '6px 18px',
+  padding: '4px 12px',
   borderRadius: '50px',
   ':focus-visible': {
     outline: 'none !important',

--- a/frontend/components/SwitchHeader/SwitchButton/style.js
+++ b/frontend/components/SwitchHeader/SwitchButton/style.js
@@ -26,7 +26,21 @@ const activeButton = css({
   },
 }).toString();
 
+const activeSwitchButton = css({
+  backgroundColor: colors.light,
+  padding: '6px 18px',
+  color: colors.dark,
+  borderRadius: '50px',
+}).toString();
+
+const switchButton = css({
+  color: colors.shade9,
+  borderRadius: '50px',
+}).toString();
+
 export default {
   button,
   activeButton,
+  switchButton,
+  activeSwitchButton,
 };

--- a/frontend/components/SwitchHeader/SwitchButton/style.js
+++ b/frontend/components/SwitchHeader/SwitchButton/style.js
@@ -26,22 +26,22 @@ const activeButton = css({
   },
 }).toString();
 
-const activeIconButton = css({
-  boxShadow: shadows.material,
-  backgroundColor: colors.light,
-  padding: '4px 12px',
+const iconButtonBase = {
+  padding: '4px 16px',
   borderRadius: '50px',
   ':focus-visible': {
     outline: 'none !important',
   },
+};
+
+const activeIconButton = css({
+  ...iconButtonBase,
+  boxShadow: shadows.material,
+  backgroundColor: colors.light,
 }).toString();
 
 const iconButton = css({
-  padding: '4px 12px',
-  borderRadius: '50px',
-  ':focus-visible': {
-    outline: 'none !important',
-  },
+  ...iconButtonBase,
 }).toString();
 
 export default {

--- a/frontend/components/SwitchHeader/SwitchButton/style.js
+++ b/frontend/components/SwitchHeader/SwitchButton/style.js
@@ -29,13 +29,17 @@ const activeButton = css({
 const activeSwitchButton = css({
   backgroundColor: colors.light,
   padding: '6px 18px',
-  color: colors.dark,
   borderRadius: '50px',
+  ' path': {
+    stroke: colors.dark,
+  },
 }).toString();
 
 const switchButton = css({
-  color: colors.shade9,
   borderRadius: '50px',
+  ' path': {
+    stroke: colors.shade9,
+  },
 }).toString();
 
 export default {

--- a/frontend/components/SwitchHeader/SwitchButton/style.js
+++ b/frontend/components/SwitchHeader/SwitchButton/style.js
@@ -30,12 +30,9 @@ const activeIconButton = css({
   boxShadow: shadows.material,
   backgroundColor: colors.light,
   padding: '6px 18px',
+  borderRadius: '50px',
   ':focus-visible': {
     outline: 'none !important',
-  },
-  borderRadius: '50px',
-  ' path': {
-    stroke: colors.dark,
   },
 }).toString();
 
@@ -44,9 +41,6 @@ const iconButton = css({
   borderRadius: '50px',
   ':focus-visible': {
     outline: 'none !important',
-  },
-  ' path': {
-    stroke: colors.shade9,
   },
 }).toString();
 

--- a/frontend/components/SwitchHeader/index.jsx
+++ b/frontend/components/SwitchHeader/index.jsx
@@ -24,10 +24,13 @@ const SwitchHeader = ({ isVisible, selection, children }) => (
           .map(link => (
             <li
               key={link.label}
-              className={classNames(
-                iconSwitch ? styles.iconMenuItem : styles.menuItem,
-                iconSwitch ? 'page-switcher__icon-menu-item' : 'page-switcher__menu-item'
-              )}
+              className={classNames({
+                [styles.iconMenuItem]: iconSwitch,
+                [styles.menuItem]: !iconSwitch,
+                'page-switcher__icon-menu-item': iconSwitch,
+                'page-switcher__menu-item': !iconSwitch,
+                active: selection.path === link.path,
+              })}
             >
               <SwitchButton
                 isActive={selection.path === link.path}

--- a/frontend/components/SwitchHeader/index.jsx
+++ b/frontend/components/SwitchHeader/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withRoute } from '@shopgate/engage/core';
+import classNames from 'classnames';
 import styles from './style';
 import connect from './connector';
 import SwitchButton from './SwitchButton';
@@ -17,11 +18,16 @@ import { pageLinking, showSwitcherInHeader, iconSwitch } from '../../config';
 const SwitchHeader = ({ isVisible, selection, children }) => (
   showSwitcherInHeader && isVisible ? (
     <nav className={styles.container}>
-      <ul className={iconSwitch ? styles.iconMenu : styles.switchMenu}>
+      <ul className={classNames(iconSwitch ? styles.iconMenu : styles.switchMenu, 'page-switcher__menu')}>
         {pageLinking
           .filter(link => !link.externalUrl)
           .map(link => (
-            <li key={link.label} className={iconSwitch ? styles.iconMenuItem : styles.menuItem}>
+            <li
+              key={link.label}
+              className={classNames(iconSwitch
+                ? styles.iconMenuItem
+                : styles.menuItem, 'page-switcher__menu-item')}
+            >
               <SwitchButton
                 isActive={selection.path === link.path}
                 link={link}

--- a/frontend/components/SwitchHeader/index.jsx
+++ b/frontend/components/SwitchHeader/index.jsx
@@ -4,7 +4,7 @@ import { withRoute } from '@shopgate/engage/core';
 import styles from './style';
 import connect from './connector';
 import SwitchButton from './SwitchButton';
-import { pageLinking, showSwitcherInHeader } from '../../config';
+import { pageLinking, showSwitcherInHeader, iconSwitch } from '../../config';
 
 /**
  * The SwitchHeader component.
@@ -17,15 +17,16 @@ import { pageLinking, showSwitcherInHeader } from '../../config';
 const SwitchHeader = ({ isVisible, selection, children }) => (
   showSwitcherInHeader && isVisible ? (
     <nav className={styles.container}>
-      <ul className={styles.switchMenu}>
+      <ul className={iconSwitch ? styles.iconMenu : styles.switchMenu}>
         {pageLinking
           .filter(link => !link.externalUrl)
           .map(link => (
-            <li key={link.label} className={styles.menuItem}>
+            <li key={link.label} className={iconSwitch ? styles.iconMenuItem : styles.menuItem}>
               <SwitchButton
                 isActive={selection.path === link.path}
                 link={link}
                 icon={link.icon}
+                isIconSwitch={iconSwitch}
               />
             </li>
           ))}

--- a/frontend/components/SwitchHeader/index.jsx
+++ b/frontend/components/SwitchHeader/index.jsx
@@ -22,7 +22,11 @@ const SwitchHeader = ({ isVisible, selection, children }) => (
           .filter(link => !link.externalUrl)
           .map(link => (
             <li key={link.label} className={styles.menuItem}>
-              <SwitchButton isActive={selection.path === link.path} link={link} />
+              <SwitchButton
+                isActive={selection.path === link.path}
+                link={link}
+                icon={link.icon}
+              />
             </li>
           ))}
       </ul>

--- a/frontend/components/SwitchHeader/index.jsx
+++ b/frontend/components/SwitchHeader/index.jsx
@@ -24,9 +24,10 @@ const SwitchHeader = ({ isVisible, selection, children }) => (
           .map(link => (
             <li
               key={link.label}
-              className={classNames(iconSwitch
-                ? styles.iconMenuItem
-                : styles.menuItem, 'page-switcher__menu-item')}
+              className={classNames(
+                iconSwitch ? styles.iconMenuItem : styles.menuItem,
+                iconSwitch ? 'page-switcher__icon-menu-item' : 'page-switcher__menu-item'
+              )}
             >
               <SwitchButton
                 isActive={selection.path === link.path}

--- a/frontend/components/SwitchHeader/style.js
+++ b/frontend/components/SwitchHeader/style.js
@@ -47,7 +47,7 @@ const iconMenu = css({
   height: '100%',
   alignItems: 'center',
   borderRadius: '50px',
-  backgroundColor: colors.shade7,
+  backgroundColor: colors.shade10,
 }).toString();
 
 const iconMenuItem = css({

--- a/frontend/components/SwitchHeader/style.js
+++ b/frontend/components/SwitchHeader/style.js
@@ -44,14 +44,13 @@ const menuItem = css({
 const iconMenu = css({
   margin: '4px 8px',
   display: 'flex',
-  height: '100%',
   alignItems: 'center',
   borderRadius: '50px',
   backgroundColor: colors.shade10,
 }).toString();
 
 const iconMenuItem = css({
-  margin: '0 4px',
+  margin: '4px',
   display: 'flex',
   alignItems: 'center',
 }).toString();

--- a/frontend/components/SwitchHeader/style.js
+++ b/frontend/components/SwitchHeader/style.js
@@ -1,4 +1,7 @@
 import { css } from 'glamor';
+import { themeConfig } from '@shopgate/engage';
+
+const { colors } = themeConfig;
 
 const container = css({
   display: 'flex',
@@ -38,8 +41,25 @@ const menuItem = css({
   },
 }).toString();
 
+const iconMenu = css({
+  margin: '4px',
+  display: 'flex',
+  height: '100%',
+  alignItems: 'center',
+  borderRadius: '50px',
+  backgroundColor: colors.shade7,
+}).toString();
+
+const iconMenuItem = css({
+  margin: '0 4px',
+  display: 'flex',
+  alignItems: 'center',
+}).toString();
+
 export default {
   switchMenu,
   menuItem,
   container,
+  iconMenu,
+  iconMenuItem,
 };

--- a/frontend/components/SwitchHeader/style.js
+++ b/frontend/components/SwitchHeader/style.js
@@ -42,7 +42,7 @@ const menuItem = css({
 }).toString();
 
 const iconMenu = css({
-  margin: '4px',
+  margin: '4px 8px',
   display: 'flex',
   height: '100%',
   alignItems: 'center',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,24 +9,12 @@
   "devDependencies": {
     "@shopgate/engage": "^6.22.4",
     "@shopgate/eslint-config": "^6.11.0",
-    "babel-core": "^6.26.0",
-    "babel-plugin-react-transform": "^3.0.0",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-export-extensions": "^6.22.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-plugin-transform-react-inline-elements": "^6.22.0",
-    "babel-plugin-transform-react-jsx": "^6.24.1",
-    "babel-preset-env": "^1.6.1",
-    "babel-preset-react": "^6.24.1",
+    "classnames": "2.5.1",
     "eslint": "^5.12.0",
     "glamor": "^2.20.40",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
-    "react-dom": "^16.2.0",
-    "react-helmet": "^5.2.0",
-    "react-transition-group": "^2.2.1",
-    "react-hot-loader": "^3.1.3",
-    "react-transform-catch-errors": "^1.0.2"
+    "react-dom": "^16.2.0"
   },
   "dependencies": {
     "@shopgate-ps/pwa-extension-kit": "^0.6.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,17 +4,11 @@
   "description": "",
   "license": "Apache-2.0",
   "scripts": {
-    "lint": "eslint --parser babel-eslint --ignore-path ../.gitignore --ignore-path .eslintignore --ext .js --ext .jsx .",
-    "test": "jest",
-    "test:watch": "npm run test -- --watch",
-    "coverage": "jest --coverage",
-    "coverage:watch": "npm run coverage -- --watch",
-    "dummy": ""
+    "lint": "eslint --parser babel-eslint --ignore-path ../.gitignore --ignore-path .eslintignore --ext .js --ext .jsx ."
   },
   "devDependencies": {
     "@shopgate/engage": "^6.22.4",
     "@shopgate/eslint-config": "^6.11.0",
-    "jest": "^22.4.2",
     "babel-core": "^6.26.0",
     "babel-plugin-react-transform": "^3.0.0",
     "babel-plugin-transform-class-properties": "^6.24.1",


### PR DESCRIPTION
For the page switcher, we now allow icons to be used in the switch menu. They can be configured in the extension config by setting "iconSwitch" to true and providing an svg to "icon" in "pageLinking".