### PR TITLE
Fix logo category drawer overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,37 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.5.0] - 2025-06-30
+## 1.5.1 - 2025-08-21
+### Fixed
+- Fixed logo overlapping category drawer icon when category drawer extension is combined with page switcher
+
+## 1.5.0 - 2025-06-30
 ### Added
 - Enable icons as page switcher buttons
 
-## [1.4.3] - 2025-06-26
+## 1.4.3 - 2025-06-26
 ### Fixed
 - Navigation aligned to the right edge and prevented from overflowing
 
-## [1.4.0] - 2025-04-01
+## 1.4.0 - 2025-04-01
 ### Changed
 - Category tree on browse page will adjust to the selected page and show the relevant child categories
 
-## [1.3.1] - 2025-03-25
+## 1.3.1 - 2025-03-25
 ### Fixed
 - Screenreader focus on active button
 - Logo is still displayed when changing pages
 
-## [1.3.0] - 2025-03-25
+## 1.3.0 - 2025-03-25
 ### Added
 - Added navigation bar, which appears below the header
 - Improved accessibility
 
-## [1.2.0] - 2024-10-21
+## 1.2.0 - 2024-10-21
 ### Added
 - Added compatibility with upcoming PWA version 7.20.0
 
-## [1.1.0] - 2024-06-21
+## 1.1.0 - 2024-06-21
 ### Added
 - Fixed redirection behavior when starting the app.
 
-## [1.0.0] - 2023-11-10
+## 1.0.0 - 2023-11-10
 ### Added
 - Adds a page switcher to the header
 - The selected page will be the start page on the next start

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.5.1-beta.1",
   "id": "@shopgate-project/page-switcher",
   "components": [
     {

--- a/frontend/components/Logo/style.js
+++ b/frontend/components/Logo/style.js
@@ -4,13 +4,6 @@ import { showSwitcherInHeader } from '../../config';
 
 const { variables } = themeConfig;
 
-// Update styling of the burger icon in the category drawer app bar
-// css.global('.category-drawer__app-bar-burger-icon', {
-//   position: 'relative',
-//   top: 'initial',
-//   transform: 'initial',
-// });
-
 const container = css({
   alignItems: 'center',
   display: 'flex',
@@ -21,7 +14,6 @@ const image = css({
   margin: '0 auto',
   marginLeft: showSwitcherInHeader ? '0' : 'auto',
   maxHeight: variables.navigator.height,
-  // maxWidth: `calc(100vw - ${(variables.navigator.height * 3) + variables.gap.xbig}px)`,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',

--- a/frontend/components/Logo/style.js
+++ b/frontend/components/Logo/style.js
@@ -5,11 +5,11 @@ import { showSwitcherInHeader } from '../../config';
 const { variables } = themeConfig;
 
 // Update styling of the burger icon in the category drawer app bar
-css.global('.category-drawer__app-bar-burger-icon', {
-  position: 'relative',
-  top: 'initial',
-  transform: 'initial',
-});
+// css.global('.category-drawer__app-bar-burger-icon', {
+//   position: 'relative',
+//   top: 'initial',
+//   transform: 'initial',
+// });
 
 const container = css({
   alignItems: 'center',
@@ -21,7 +21,7 @@ const image = css({
   margin: '0 auto',
   marginLeft: showSwitcherInHeader ? '0' : 'auto',
   maxHeight: variables.navigator.height,
-  maxWidth: `calc(100vw - ${(variables.navigator.height * 3) + variables.gap.xbig}px)`,
+  // maxWidth: `calc(100vw - ${(variables.navigator.height * 3) + variables.gap.xbig}px)`,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',


### PR DESCRIPTION
We are fixing the following issue: When using the category drawer in combination with the page switcher extension in the setting "showAppBarNavDrawer", the category drawer icon overlaps the logo in the app header. 